### PR TITLE
Injecting src/href as data-old-Attributes

### DIFF
--- a/htmldiff2.py
+++ b/htmldiff2.py
@@ -106,12 +106,11 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
         attrs |= [(QName('class'), cls and cls + ' ' + classname or classname)]
         return attrs
 
-    def inject_src(self, attrs):
+    def inject_src(self, attrs, old_attrs):
         src = attrs.get('src')
-        ### How to get the old src-attribute? This did not work:
-        # old_src = dict(self._old).get('src')
-        old_src = attrs.get('src')
-        attrs |= [(QName('data-old-src'), old_src and old_src or src)]
+        old_src = old_attrs.get('src')
+        attrs |= [(QName('src'), src)]
+        attrs |= [(QName('data-old-src'), old_src)]
         return attrs
 
     def append(self, type, data, pos):
@@ -174,8 +173,9 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
                 type = old_event[0]
                 # start tags are easy. handle them first.
                 if type == START:
+                    old_, (old_tag, old_attrs), old_pos = old_event
                     _, (tag, attrs), pos = new_event
-                    self.enter_mark_replaced(pos, tag, attrs)
+                    self.enter_mark_replaced(pos, tag, attrs, old_attrs)
                 # ends in replacements are a bit tricker, we try to
                 # leave the new one first, then the old one. One
                 # should succeed.
@@ -234,9 +234,9 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
         self._stack.append(tag)
         self.append(START, (tag, attrs), pos)
 
-    def enter_mark_replaced(self, pos, tag, attrs):
+    def enter_mark_replaced(self, pos, tag, attrs, old_attrs):
         attrs = self.inject_class(attrs, 'tagdiff_replaced')
-        attrs = self.inject_src(attrs)
+        attrs = self.inject_src(attrs, old_attrs)
         self._stack.append(tag)
         self.append(START, (tag, attrs), pos)
 

--- a/htmldiff2.py
+++ b/htmldiff2.py
@@ -106,6 +106,14 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
         attrs |= [(QName('class'), cls and cls + ' ' + classname or classname)]
         return attrs
 
+    def inject_src(self, attrs):
+        src = attrs.get('src')
+        ### How to get the old src-attribute? This did not work:
+        # old_src = dict(self._old).get('src')
+        old_src = attrs.get('src')
+        attrs |= [(QName('data-old-src'), old_src and old_src or src)]
+        return attrs
+
     def append(self, type, data, pos):
         self._result.append((type, data, pos))
 
@@ -228,6 +236,7 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
 
     def enter_mark_replaced(self, pos, tag, attrs):
         attrs = self.inject_class(attrs, 'tagdiff_replaced')
+        attrs = self.inject_src(attrs)
         self._stack.append(tag)
         self.append(START, (tag, attrs), pos)
 

--- a/htmldiff2.py
+++ b/htmldiff2.py
@@ -106,11 +106,12 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
         attrs |= [(QName('class'), cls and cls + ' ' + classname or classname)]
         return attrs
 
-    def inject_src(self, attrs, old_attrs):
-        src = attrs.get('src')
-        old_src = old_attrs.get('src')
-        attrs |= [(QName('src'), src)]
-        attrs |= [(QName('data-old-src'), old_src)]
+    def inject_refattr(self, attrs, old_attrs):
+        for attr in ['src', 'href']:
+            old_attr = old_attrs.get(attr)
+            new_attr = attrs.get(attr)
+            attrs |= [(QName(attr), new_attr)]
+            attrs |= [(QName('data-old-%s' % attr), old_attr)]
         return attrs
 
     def append(self, type, data, pos):
@@ -236,7 +237,7 @@ so the tags the `StreamDiffer` adds are also unnamespaced.
 
     def enter_mark_replaced(self, pos, tag, attrs, old_attrs):
         attrs = self.inject_class(attrs, 'tagdiff_replaced')
-        attrs = self.inject_src(attrs, old_attrs)
+        attrs = self.inject_refattr(attrs, old_attrs)
         self._stack.append(tag)
         self.append(START, (tag, attrs), pos)
 

--- a/htmldiff2.py
+++ b/htmldiff2.py
@@ -17,6 +17,9 @@
     >>> print(render_html_diff('Foo baz', 'Foo blah baz'))
     <div class="diff">Foo <ins>blah</ins> baz</div>
 
+    >>> print(render_html_diff('<img src="pic0.jpg"/>', '<img src="pic1.jpg"/>'))
+    <div class="diff"><img src="pic1.jpg" class="tagdiff_replaced" data-old-src="pic0.jpg"></div>
+
     :copyright: (c) 2011 by Armin Ronacher, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """


### PR DESCRIPTION
@edsu Thanks for the great work on _htmldiff2_.
It's really perfect for comparing workflow-based content changes in rendered HTML.

We were thinking about one detail: 
Currently _htmldiff2_ marks all attribute changes unspecifically as `tagdiff_replaced` (which should be good enough in most cases). But there are some very relevant attributes like `img.src` and `a.href` that have a massive impact on the content. So we suggest to transfer/"inject" them as `data` attributes into the diff output. This allows to optionally highlight the content changes with CSS/JS like this (lower part):

![img_diff](https://github.com/user-attachments/assets/ef1696a5-6601-4c32-b54b-6e1b2edb90e2)

Maybe you like the idea? 
Looking forward to your feedback
drfho/Frank
