### PR TITLE
Set regex flags separately

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.13]
     steps:
 
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 .eggs
 .venv
 .python-version
+build
 
 # Coverage
 .coverage

--- a/htmldiff2.py
+++ b/htmldiff2.py
@@ -34,8 +34,8 @@ from contextlib import contextmanager
 import html5lib
 
 
-_leading_space_re = re.compile(r'^(\s+)(?u)')
-_diff_split_re = re.compile(r'(\s+)(?u)')
+_leading_space_re = re.compile(r'^(\s+)', re.U)
+_diff_split_re = re.compile(r'(\s+)', re.U)
 
 
 def diff_genshi_stream(old_stream, new_stream):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "htmldiff2"
-version = "0.2.1"
+version = "0.2.2"
 description = "Diffs arbitrary HTML inline."
 readme = "README.md"
 requires-python = ">=2.7"


### PR DESCRIPTION
Move the unicode option to a flag. This is the default, but still does something useful on python2.7.

Fixes #1
